### PR TITLE
Fix bug when preselecting headings

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -377,12 +377,14 @@ will be refiled."
                     (org-refile nil nil rfloc))))))
 
 (defun helm-org-in-buffer-preselect ()
-  "Preselect function for `helm-org-in-buffer-headings'."
-  (if (org-on-heading-p)
-      (buffer-substring-no-properties (point-at-bol) (point-at-eol))
-      (save-excursion
-        (outline-previous-visible-heading 1)
-        (buffer-substring-no-properties (point-at-bol) (point-at-eol)))))
+  "Return the current or closest visible heading as a regexp string."
+  (save-excursion
+    (cond ((org-at-heading-p) (forward-line 0))
+	  ((org-before-first-heading-p)
+	   (outline-next-visible-heading 1))
+	  (t (outline-previous-visible-heading 1)))
+    (regexp-quote (buffer-substring-no-properties (point)
+						  (point-at-eol)))))
 
 (defun helm-org-run-refile-heading-to ()
   "Helm org refile heading action."


### PR DESCRIPTION
* helm-org.el (helm-org-in-buffer-preselect): Do it.

This happens if the heading contains brackets: [#A] etc. I'm also
moving the point to the closest heading.

This commit was left out for some reason. I also changed `point-at-bol` to `point`.