### PR TITLE
fixed the error message from helm-org auto-loading.

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -36,12 +36,13 @@
 
 ;; Menu
 ;;;###autoload
-(easy-menu-add-item
- nil '("Tools" "Helm")
- '("Org"
-   ["Org headlines in org agenda files" helm-org-agenda-files-headings t]
-   ["Org headlines in buffer" helm-org-in-buffer-headings t])
- "Elpa")
+(eval-after-load 'helm-easymenu
+  '(easy-menu-add-item
+    nil '("Tools" "Helm")
+    '("Org"
+      ["Org headlines in org agenda files" helm-org-agenda-files-headings t]
+      ["Org headlines in buffer" helm-org-in-buffer-headings t])
+    "Elpa"))
 
 
 ;; Load org-with-point-at macro when compiling


### PR DESCRIPTION
There is error message while auto-loading helm-org as follow, in which the menu for helm not exist, the modification will create helm-org menu after helm creating menu.