### PR TITLE
Use `org-store-link' when inserting links

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -360,11 +360,11 @@ Get PARENTS as well when specified."
   (with-current-buffer (marker-buffer marker)
     (let ((bracket-link (save-excursion
                           (goto-char (marker-position marker))
-                          (org-store-link nil nil)))
-          (file-name (buffer-file-name)))
+                          (org-link-unescape
+                           (org-store-link nil nil)))))
       (with-helm-current-buffer
         (string-match org-bracket-link-regexp bracket-link)
-        (org-insert-link file-name (match-string 1 bracket-link))))))
+        (org-insert-link nil (match-string 1 bracket-link))))))
 
 (defun helm-org-run-insert-link-to-heading-at-marker ()
   "Run interactively `helm-org-insert-link-to-heading-at-marker'."

--- a/helm-org.el
+++ b/helm-org.el
@@ -358,12 +358,15 @@ Get PARENTS as well when specified."
 (defun helm-org-insert-link-to-heading-at-marker (marker)
   "Insert link to heading at MARKER position."
   (with-current-buffer (marker-buffer marker)
-    (let ((heading-name (save-excursion (goto-char (marker-position marker))
-                                        (nth 4 (org-heading-components))))
+    (let ((bracket-link (save-excursion
+                          (goto-char (marker-position marker))
+                          (org-store-link nil nil)))
           (file-name (buffer-file-name)))
       (with-helm-current-buffer
-        (org-insert-link
-         file-name (concat "file:" file-name "::*" heading-name))))))
+        (string-match org-bracket-link-regexp bracket-link)
+        (org-insert-link file-name
+                         (match-string 1 bracket-link)
+                         (match-string 3 bracket-link))))))
 
 (defun helm-org-run-insert-link-to-heading-at-marker ()
   "Run interactively `helm-org-insert-link-to-heading-at-marker'."

--- a/helm-org.el
+++ b/helm-org.el
@@ -364,9 +364,7 @@ Get PARENTS as well when specified."
           (file-name (buffer-file-name)))
       (with-helm-current-buffer
         (string-match org-bracket-link-regexp bracket-link)
-        (org-insert-link file-name
-                         (match-string 1 bracket-link)
-                         (match-string 3 bracket-link))))))
+        (org-insert-link file-name (match-string 1 bracket-link))))))
 
 (defun helm-org-run-insert-link-to-heading-at-marker ()
   "Run interactively `helm-org-insert-link-to-heading-at-marker'."


### PR DESCRIPTION
This allows inserting links based on unique IDs if `org-id-link-to-org-use-id` is set to `t`.

The non-interactive call to `org-insert-link` shoudn't have any side-effects.