### PR TITLE
Use dynamic completion

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -219,8 +219,7 @@ current heading."
     :match-dynamic t
     :action 'helm-org-headings-actions
     :keymap helm-org-headings-map
-    :group 'helm-org
-    :requires-pattern 2))
+    :group 'helm-org))
 
 (defun helm-org-get-candidates (filenames &optional parents)
   "Get org headings for file FILENAMES.

--- a/helm-org.el
+++ b/helm-org.el
@@ -237,7 +237,7 @@ Get PARENTS as well when specified."
   (with-current-buffer (pcase filename
                          ((pred bufferp) filename)
                          ((pred stringp) (find-file-noselect filename t)))
-    (let ((tick (buffer-modified-tick)))
+    (let ((tick (buffer-chars-modified-tick)))
       (if (and helm-org--buffer-tick
                (= tick helm-org--buffer-tick))
           helm-org--headers-cache

--- a/helm-org.el
+++ b/helm-org.el
@@ -210,7 +210,12 @@ current heading."
     :candidates (helm-dynamic-completion
                  (helm-org-get-candidates
                   filenames parents)
-                 'stringp)
+                 'stringp
+                 nil '(metadata (display-sort-function
+                                 .
+                                 (lambda (candidates)
+                                   (sort candidates
+                                         #'helm-generic-sort-fn)))))
     :match-dynamic t
     :action 'helm-org-headings-actions
     :keymap helm-org-headings-map

--- a/helm-org.el
+++ b/helm-org.el
@@ -277,25 +277,25 @@ Get PARENTS as well when specified."
                    for heading = (funcall match-fn 4)
                    if (and (>= level helm-org-headings-min-depth)
                            (<= level helm-org-headings-max-depth))
-                   collect `(,(propertize
-                               (if helm-org-format-outline-path
-                                   (org-format-outline-path
-                                    ;; org-get-outline-path changed in signature and behaviour since org's
-                                    ;; commit 105a4466971. Let's fall-back to the new version in case
-                                    ;; of wrong-number-of-arguments error.
-                                    (condition-case nil
-                                        (append (apply #'org-get-outline-path
-                                                       (unless parents
-                                                         (list t level heading)))
-                                                (list heading))
-                                      (wrong-number-of-arguments
-                                       (org-get-outline-path t t)))
-                                    width file)
-                                   (if file
-                                       (concat file (funcall match-fn  0))
-                                       (funcall match-fn  0)))
-                               'helm-real-display heading)
-                              . ,(point-marker))))))))
+                   collect (propertize
+                            (if helm-org-format-outline-path
+                                (org-format-outline-path
+                                 ;; org-get-outline-path changed in signature and behaviour since org's
+                                 ;; commit 105a4466971. Let's fall-back to the new version in case
+                                 ;; of wrong-number-of-arguments error.
+                                 (condition-case nil
+                                     (append (apply #'org-get-outline-path
+                                                    (unless parents
+                                                      (list t level heading)))
+                                             (list heading))
+                                   (wrong-number-of-arguments
+                                    (org-get-outline-path t t)))
+                                 width file)
+                              (if file
+                                  (concat file (funcall match-fn  0))
+                                (funcall match-fn  0)))
+                            'helm-real-display heading
+                            'helm-realvalue (point-marker))))))))
 
 (defun helm-org-insert-link-to-heading-at-marker (marker)
   "Insert link to heading at MARKER position."

--- a/helm-org.el
+++ b/helm-org.el
@@ -261,11 +261,7 @@ Get PARENTS as well when specified."
           (and (boundp 'org-outline-path-cache)
                (setq org-outline-path-cache nil))
           (cl-loop with width = (window-width (helm-window))
-                   while (and (funcall search-fn)
-                              (string-match-p
-                               helm-pattern
-                               (buffer-substring-no-properties
-                                (point-at-bol) (point-at-eol))))
+                   while (funcall search-fn)
                    for beg = (point-at-bol)
                    for end = (point-at-eol)
                    when (and fontify

--- a/helm-org.el
+++ b/helm-org.el
@@ -369,7 +369,6 @@ will be refiled."
               (y-or-n-p (format "%s have auto save data, continue? "
                                 (mapconcat #'identity autosaves ", "))))
       (helm :sources (helm-source-org-headings-for-files files)
-            :candidate-number-limit 99999
             :truncate-lines helm-org-truncate-lines
             :buffer "*helm org headings*"))))
 
@@ -382,7 +381,6 @@ will be refiled."
         org-startup-indented
         org-hide-leading-stars)
     (helm :sources (helm-source-org-headings-for-files files)
-          :candidate-number-limit 99999
           :preselect (helm-org-in-buffer-preselect)
           :truncate-lines helm-org-truncate-lines
           :buffer "*helm org inbuffer*")))
@@ -396,7 +394,6 @@ will be refiled."
         (helm-org-headings-max-depth  50)
         (files (list (current-buffer))))
     (helm :sources (helm-source-org-headings-for-files files t)
-          :candidate-number-limit 99999
           :truncate-lines helm-org-truncate-lines
           :buffer "*helm org parent headings*")))
 
@@ -405,7 +402,6 @@ will be refiled."
   "Preconfigured helm for org templates."
   (interactive)
   (helm :sources (helm-source-org-capture-templates)
-        :candidate-number-limit 99999
         :truncate-lines helm-org-truncate-lines
         :buffer "*helm org capture templates*"))
 


### PR DESCRIPTION
DON'T MERGE, just a proof of concept, let me know people with large org files if it's faster.
Thanks. @alphapapa ping.

helm-org-startup-visibility filter have been disabled for now as it is
not working for some reasons (seems also it slowdown helm-org).

When submitting a pull request, please include the following information:

* **Emacs versions tested with:** 
Emacs-26
* **Org versions tested with:**
The version coming with emacs-26 
* **`helm` versions tested with:** 
Last.
* **`helm-core` versions tested with:** 
Last.
