### PR TITLE
Collect refile destination so it can be logged on completion.

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -396,7 +396,12 @@ will be refiled."
   (let* ((victims (with-helm-buffer (helm-marked-candidates)))
          (buffer (marker-buffer marker))
          (filename (buffer-file-name buffer))
-         (rfloc (list nil filename nil marker)))
+         ;; get the heading we refile to so org doesn't
+         ;; output 'Refile to "nil" in file ...'
+         (heading (with-current-buffer buffer
+                    (org-with-point-at marker
+                      (org-get-heading :no-tags :no-todo :no-priority :no-comment))))
+         (rfloc (list heading filename nil marker)))
     (when (and (= 1 (length victims))
                (equal (helm-get-selection) (car victims)))
       ;; No candidates are marked; we are refiling the entry at point


### PR DESCRIPTION
This change grabs the target headline of the refile action so we get a better success message.

Before:

> Refile to "nil" in file /home/a/Documents/Org/File.org: done

After:

> Refile to "Headline X" in file /home/a/Documents/Org/File.org: done

The change requires org-mode version >= 9.1, released in 2017, 28 releases ago judging by the tags. Previously `org-get-heading` lacks the `no-priority` & `no-comment` parameters. I hope this is sufficient for the don't-break-old-versions policy.

* **Emacs versions tested with:** 
`GNU Emacs 26.3 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.24.10) of 2019-08-29`
* **Org versions tested with:** 
`Org mode version 9.3.1 (9.3.1-elpaplus @ /home/a/.emacs.d/elpa/26.3/develop/org-plus-contrib-20191230/)`
* **`helm` versions tested with:** 
`3.5.6`
* **`helm-core` versions tested with:** 
`20191223.1914`
