### PR TITLE
Don't restrict org outline path length

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -295,8 +295,7 @@ Get PARENTS as well when specified."
                        ;; clear cache for new version of org-get-outline-path
                        (and (boundp 'org-outline-path-cache)
                             (setq org-outline-path-cache nil))
-                       (cl-loop with width = (window-width (helm-window))
-                                while (funcall search-fn)
+                       (cl-loop while (funcall search-fn)
                                 for beg = (point-at-bol)
                                 for end = (point-at-eol)
                                 when (and fontify
@@ -320,7 +319,7 @@ Get PARENTS as well when specified."
                                                           (list heading))
                                                 (wrong-number-of-arguments
                                                  (org-get-outline-path t t)))
-                                              width file)
+                                              999 file)
                                            (if file
                                                (concat file (funcall match-fn  0))
                                              (funcall match-fn  0)))


### PR DESCRIPTION
This tries to address two issues by removing restriction of outline path length to window width in `helm-org-agenda-files-headings`:

1. Truncating the outline paths seems counterproductive.
2. Bug: The org outline path candidates for `helm-org-agenda-files-headings` get truncated to the width of the previously active window, not the helm-window.

**Reasoning for 1.:**
The leaf node is likely the most interesting part of the candidate, it shouldn't be cut off. In comparable scenarios like `helm-find-files` there is also no truncation.

Not truncating candidates will use the full helm window width, and users can use horizontal scrolling or wrapping (via `helm-org-truncate-lines` or `helm-toggle-truncate-line`) to inspect the full path if required.

**Repro steps for 2.:**
- Start emacs, split window vertically
- Open some org file and create entries that result in outline paths longer than the current window width
- Ensure that org file is part of org-agenda-files
- Call `helm-org-agenda-files-headings`
- The helm candidate window should open below the 2 existing vertically split windows, using the full frame width
- The candidates are truncated to match the org window width, not the helm window width

The reason seems to be that `helm-window` returns `nil` when `helm-org--get-candidates-in-file` is called, so the `window-width` call returns the width of the current window instead.

Behaviour seems similar to the now inaccessible issue 1294 in helm, if that is of any relevance. Still available currently via google webcache: 
https://webcache.googleusercontent.com/search?q=cache:BPTMko9B-8kJ:https://github.com/emacs-helm/helm/issues/1294


* **Emacs versions tested with:** 
`GNU Emacs 27.1 (build 1, x86_64-pc-linux-gnu, GTK+ Version 3.22.30, cairo version 1.15.10) of 2020-09-19`
* **Org versions tested with:** 
`Org version 9.4 from package org-plus-contrib version 20201005`
* **`helm` versions tested with:** 
`3.6.2`
* **`helm-core` versions tested with:** 
`20200905.1311`

