### PR TITLE
Add clock-in action

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -99,7 +99,8 @@ NOTE: This will be slow on large org buffers."
   '(("Go to heading" . helm-org-goto-marker)
     ("Open in indirect buffer `C-c i'" . helm-org--open-heading-in-indirect-buffer)
     ("Refile heading(s) (marked-to-selected|current-to-selected) `C-c w`" . helm-org--refile-heading-to)
-    ("Insert link to this heading `C-c l`" . helm-org-insert-link-to-heading-at-marker))
+    ("Insert link to this heading `C-c l`" . helm-org-insert-link-to-heading-at-marker)
+    ("Clock-in this heading" . helm-org-clock-in))
   "Default actions alist for `helm-source-org-headings-for-files'."
   :group 'helm-org
   :type '(alist :key-type string :value-type function))
@@ -412,6 +413,11 @@ will be refiled."
       (cl-loop for victim in victims
                do (org-with-point-at victim
                     (org-refile nil nil rfloc))))))
+
+(defun helm-org-clock-in (marker)
+  "Start the clock on the heading pointed by the MARKER."
+  (helm-org-goto-marker marker)
+  (org-clock-in))
 
 (defun helm-org-in-buffer-preselect ()
   "Return the current or closest visible heading as a regexp string."


### PR DESCRIPTION
Another common use case to search through headers is to start the clock. This PR adds an action to do so.

<hr />

When submitting a pull request, please include the following information:

* **Emacs versions tested with:** 

GNU Emacs 27.1 (build 1, x86_64-pc-linux-gnu, X toolkit, cairo version 1.15.10, Xaw scroll bars) of 2020-08-10

* **Org versions tested with:** 

Org mode version 9.4.2 (9.4.2-1-g162e0e-elpa

* **`helm` versions tested with:** 

Helm version 3.6.2 (elpa/helm-20201217.828)

* **`helm-core` versions tested with:** 

Helm version 3.6.2  (elpa/helm-core-20201216.928)