### PR TITLE
Insert link with `org-store-link'

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -374,12 +374,10 @@ nothing to CANDIDATES."
 (defun helm-org-insert-link-to-heading-at-marker (marker)
   "Insert link to heading at MARKER position."
   (with-current-buffer (marker-buffer marker)
-    (let ((heading-name (save-excursion (goto-char (marker-position marker))
-                                        (nth 4 (org-heading-components))))
-          (file-name (buffer-file-name)))
+    (let ((link (save-excursion (goto-char (marker-position marker))
+					(org-store-link nil))))
       (with-helm-current-buffer
-        (org-insert-link
-         file-name (concat "file:" file-name "::*" heading-name))))))
+	(insert link)))))
 
 (defun helm-org-run-insert-link-to-heading-at-marker ()
   "Run interactively `helm-org-insert-link-to-heading-at-marker'."


### PR DESCRIPTION
This patch allows us to insert a link to the headline with configurable backend (org-id for example) instead of hardcoded `filename::*Heading`

When submitting a pull request, please include the following information:

* **Emacs versions tested with:** "GNU Emacs 28.0.50 (build 1, x86_64-apple-darwin19.6.0, NS appkit-1894.60 Version 10.15.7 (Build 19H15))"
* **Org versions tested with:** "GNU Emacs 28.0.50 (build 1, x86_64-apple-darwin19.6.0, NS appkit-1894.60 Version 10.15.7 (Build 19H15))"
* **`helm` versions tested with:** 3.6.2
* **`helm-core` versions tested with:**  3.6.2

Note that Emacs and Org versions persist "in the wild" for some time after release, so it is **not** appropriate to only test with the latest released or development versions of Org; tests must include versions still commonly in use.  Proposed changes **must not** break functionality for existing users.
