### PR TITLE
helm-org-insert-link-to-heading-at-marker now supports ID properties

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -375,13 +375,10 @@ nothing to CANDIDATES."
 
 (defun helm-org-insert-link-to-heading-at-marker (marker)
   "Insert link to heading at MARKER position."
-  (with-current-buffer (marker-buffer marker)
-    (let ((heading-name (save-excursion (goto-char (marker-position marker))
-                                        (nth 4 (org-heading-components))))
-          (file-name (buffer-file-name)))
-      (with-helm-current-buffer
-        (org-insert-link
-         file-name (concat "file:" file-name "::*" heading-name))))))
+  (save-excursion
+    (goto-char (marker-position marker))
+    (call-interactively 'org-store-link))
+  (call-interactively 'org-insert-last-stored-link))
 
 (defun helm-org-run-insert-link-to-heading-at-marker ()
   "Run interactively `helm-org-insert-link-to-heading-at-marker'."


### PR DESCRIPTION
Solves #25 and is a shorter rewriting of #23.

This have been accomplished by rewriting the function in order for it
to use org-store-link and org-insert-last-stored-link. Thus, the user
is able to decide whether headlines must be referenced through their
IDs (by setting org-id-link-to-org-use-id to t) or through their
names.

When submitting a pull request, please include the following information:

* **Emacs versions tested with:** GNU Emacs 27.2
* **Org versions tested with:** 9.4.4 (release_9.4.4 @ /usr/share/emacs/27.2/lisp/org/)
* **`helm` versions tested with:** 20210324.1927
* **`helm-core` versions tested with:** 20210704.556

Note that Emacs and Org versions persist "in the wild" for some time after release, so it is **not** appropriate to only test with the latest released or development versions of Org; tests must include versions still commonly in use.  Proposed changes **must not** break functionality for existing users.
