### PR TITLE
Add menu items after helm-easymenu is loaded

### DIFF
--- a/helm-org.el
+++ b/helm-org.el
@@ -43,8 +43,7 @@
 
 ;; Menu
 ;;;###autoload
-(progn
-  (require 'helm-easymenu)
+(with-eval-after-load 'helm-easymenu
   (easy-menu-add-item
    nil '("Tools" "Helm")
    '("Org"


### PR DESCRIPTION
Allow users the choice to defer loading of helm-easymenu.

* **Emacs versions tested with:** 30.2
* **Org versions tested with:** 9.7.39
* **`helm` versions tested with:** 4.0.6
* **`helm-core` versions tested with:** 4.0.6